### PR TITLE
Initialize the Slack auth token

### DIFF
--- a/config/initializers/slack.rb
+++ b/config/initializers/slack.rb
@@ -1,0 +1,3 @@
+Slack.configure do |config|
+  config.token = ENV.fetch('SLACK_API_TOKEN')
+end


### PR DESCRIPTION
Reason for Change
=================
* The API token is necessary to auth into the Slack instance and channel.

Changes
=======
* Add an initializer for this token using the Slack notifier.