### PR TITLE
Calculate top commentors and post results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .byebug_history
 /.bundle
 /.env.local
+/.env.test
 /coverage/*
 /db/*.sqlite3
 /db/*.sqlite3-journal

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'pry-byebug'
   gem 'pry-rails'
+  gem 'rerun'
   gem 'rspec-rails', '~> 3.6'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,8 @@ GEM
     recipient_interceptor (0.1.2)
       mail
     redis (4.0.1)
+    rerun (0.11.0)
+      listen (~> 3.0)
     rspec-core (3.7.0)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -291,6 +293,7 @@ DEPENDENCIES
   rack-timeout
   rails (~> 5.1.3)
   recipient_interceptor
+  rerun
   rspec-rails (~> 3.6)
   sass-rails (~> 5.0)
   shoulda-matchers

--- a/app/jobs/stats_for_recent_comments_job.rb
+++ b/app/jobs/stats_for_recent_comments_job.rb
@@ -1,0 +1,7 @@
+class StatsForRecentCommentsJob < ActiveJob::Base
+  DEFAULT_CHANNEL = '#random'
+
+  def perform
+    StatsCalculator.new(channel: DEFAULT_CHANNEL).run
+  end
+end

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -2,7 +2,7 @@ class Notifier
   CHANNEL = '#random'
   USERNAME = 'notifier'
 
-  def send(message)
+  def send_message(message:)
     notifier.ping(message)
   end
 

--- a/app/services/stats_calculator.rb
+++ b/app/services/stats_calculator.rb
@@ -1,0 +1,51 @@
+class StatsCalculator
+  def initialize(channel:)
+    @channel = channel
+  end
+
+  def run
+    Notifier.new.send_message(message: formatted_stats_message)
+  end
+
+  private
+
+  attr_reader :channel
+
+  def formatted_stats_message
+    "User '#{top_user_name}' is the top commentor with #{top_user[1]} messages"
+  end
+
+  def top_user_name
+    profile_information.dig('profile', 'real_name')
+  end
+
+  def profile_information
+    @_profile ||= client.users_profile_get(user: top_user[0])
+  end
+
+  def top_user
+    stats.max_by{|key,value| value}
+  end
+
+  def stats
+    messages.each_with_object(Hash.new(0)) do |message, memo|
+      username = message['user']
+
+      if username.present? && message['subtype'].blank?
+        memo[username] += 1
+      end
+    end
+  end
+
+  def messages
+    data.fetch('messages')
+  end
+
+  def data
+    @_data ||= client.channels_history(channel: channel)
+  end
+
+  def client
+    Slack::Web::Client.new
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,9 @@ require "action_mailer/railtie"
 require "action_view/railtie"
 require "action_cable/engine"
 require "sprockets/railtie"
+
 Bundler.require(*Rails.groups)
+
 module Listen
   class Application < Rails::Application
     config.assets.quiet = true
@@ -24,6 +26,6 @@ module Listen
     config.action_controller.action_on_unpermitted_parameters = :raise
     config.load_defaults 5.1
     config.generators.system_tests = nil
-    config.active_job.queue_adapter = :delayed_job
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,5 +1,5 @@
 if Rails.env.development? || Rails.env.test?
-  require "factory_girl"
+  require "factory_bot"
 
   namespace :dev do
     desc "Sample data for local development environment"

--- a/spec/helpers/fixtures/channel_history.json
+++ b/spec/helpers/fixtures/channel_history.json
@@ -1,0 +1,82 @@
+{
+  "ok":true,
+  "messages":[
+    {
+      "type":"message",
+      "user":"U1T6CRY11",
+      "text":"hello1",
+      "ts":"1511297677.000569"
+    },
+    {
+      "type":"message",
+      "user":"U1T6CRY11",
+      "text":"hello2",
+      "ts":"1511297677.000569"
+    },
+    {
+      "text":"added an integration to this channel: \u003chttps://cylinderdigital.slack.com/services/B83ULS9EG|listen\u003e",
+      "bot_id":"B83ULS9EG",
+      "bot_link":"\u003chttps://cylinderdigital.slack.com/services/B83ULS9EG|listen\u003e",
+      "type":"message",
+      "subtype":"bot_add",
+      "user":"U1T6CRY11",
+      "ts":"1511297625.000270"
+    },
+    {
+      "text":"added an integration to this channel: \u003chttps://cylinderdigital.slack.com/services/B83UKM53N|listen\u003e",
+      "bot_id":"B83UKM53N",
+      "bot_link":"\u003chttps://cylinderdigital.slack.com/services/B83UKM53N|listen\u003e",
+      "type":"message",
+      "subtype":"bot_add",
+      "user":"U1T6CRY11",
+      "ts":"1511297479.000633"
+    },
+    {
+      "text":"added an integration to this channel: \u003chttps://cylinderdigital.slack.com/services/B8420CXT7|listen\u003e",
+      "bot_id":"B8420CXT7",
+      "bot_link":"\u003chttps://cylinderdigital.slack.com/services/B8420CXT7|listen\u003e",
+      "type":"message",
+      "subtype":"bot_add",
+      "user":"U1T6CRY11",
+      "ts":"1511297379.000240"
+    },
+    {
+      "text":"Hello from Rails",
+      "bot_id":"B83UG8R8D",
+      "type":"message",
+      "subtype":"bot_message",
+      "ts":"1511290112.000727"
+    },
+    {
+      "text":"Hello from Rails",
+      "bot_id":"B83UG8R8D",
+      "type":"message",
+      "subtype":"bot_message",
+      "ts":"1511289716.000136"
+    },
+    {
+      "text":"Hello, World!",
+      "bot_id":"B83UG8R8D",
+      "type":"message",
+      "subtype":"bot_message",
+      "ts":"1511288885.000491"
+    },
+    {
+      "text":"added an integration to this channel: \u003chttps://cylinderdigital.slack.com/services/B83UG8R8D|listen\u003e",
+      "bot_id":"B83UG8R8D",
+      "bot_link":"\u003chttps://cylinderdigital.slack.com/services/B83UG8R8D|listen\u003e",
+      "type":"message",
+      "subtype":"bot_add",
+      "user":"U1T6CRY11",
+      "ts":"1511286827.000091"
+    },
+    {
+      "user":"U1T6CRY11",
+      "text":"\u003c@U1T6CRY11\u003e has joined the channel",
+      "type":"message",
+      "subtype":"channel_join",
+      "ts":"1468962490.000002"
+    }
+  ],
+  "has_more":false
+}

--- a/spec/helpers/fixtures/user_data.json
+++ b/spec/helpers/fixtures/user_data.json
@@ -1,0 +1,26 @@
+{
+  "ok": true,
+  "profile": {
+    "first_name": "Adarsh",
+    "last_name": "Pandit",
+    "avatar_hash": "387387093c87",
+    "image_24": "https://avatars.slack-edge.com/2016-07-20/61683529302_387387093c87eb6b0eda_24.png",
+    "image_32": "https://avatars.slack-edge.com/2016-07-20/61683529302_387387093c87eb6b0eda_32.png",
+    "image_48": "https://avatars.slack-edge.com/2016-07-20/61683529302_387387093c87eb6b0eda_48.png",
+    "image_72": "https://avatars.slack-edge.com/2016-07-20/61683529302_387387093c87eb6b0eda_72.png",
+    "image_192": "https://avatars.slack-edge.com/2016-07-20/61683529302_387387093c87eb6b0eda_192.png",
+    "image_512": "https://avatars.slack-edge.com/2016-07-20/61683529302_387387093c87eb6b0eda_512.png",
+    "image_1024": "https://avatars.slack-edge.com/2016-07-20/61683529302_387387093c87eb6b0eda_512.png",
+    "image_original": "https://avatars.slack-edge.com/2016-07-20/61683529302_387387093c87eb6b0eda_original.png",
+    "title": "guy",
+    "phone": "123-456-6789",
+    "status_text": "",
+    "status_emoji": "",
+    "real_name": "Adarsh Pandit",
+    "display_name": "adarsh",
+    "real_name_normalized": "Adarsh Pandit",
+    "display_name_normalized": "adarsh",
+    "email": "adarsh@example.com",
+    "fields": null
+  }
+}

--- a/spec/jobs/statistics_for_recent_comments_job_spec.rb
+++ b/spec/jobs/statistics_for_recent_comments_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe StatsForRecentCommentsJob do
+  describe '#perform' do
+    it 'calculates the statistics and sends a message' do
+      calculator = double(run: nil)
+      allow(StatsCalculator).to receive(:new).and_return(calculator)
+
+      StatsForRecentCommentsJob.new.perform
+
+      expect(StatsCalculator).to have_received(:new).
+        with(channel: StatsForRecentCommentsJob::DEFAULT_CHANNEL)
+      expect(calculator).to have_received(:run)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,11 +1,12 @@
-ENV["RACK_ENV"] = "test"
+ENV['RACK_ENV'] = 'test'
 
-require File.expand_path("../../config/environment", __FILE__)
-abort("DATABASE_URL environment variable is set") if ENV["DATABASE_URL"]
+require File.expand_path('../../config/environment', __FILE__)
+abort('DATABASE_URL environment variable is set') if ENV['DATABASE_URL']
 
-require "rspec/rails"
+require 'rspec/rails'
+require 'sidekiq/testing'
 
-Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
+Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |file| require file }
 
 module Features
   # Extend this module in spec/support/features/*.rb
@@ -17,6 +18,10 @@ RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = false
+
+  config.before(:each) do
+    Sidekiq::Worker.clear_all
+  end
 end
 
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/services/stats_calculator_spec.rb
+++ b/spec/services/stats_calculator_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe StatsCalculator do
+  describe '#run' do
+    it 'gets the messages from the channel' do
+      notifier = double(send_message: nil)
+      allow(Notifier).to receive(:new).and_return(notifier)
+      client = double(
+        channels_history: channel_history,
+        users_profile_get: user_data,
+      )
+      allow(Slack::Web::Client).to receive(:new).and_return(client)
+
+      StatsCalculator.new(channel: '#random').run
+
+      expect(client).to have_received(:channels_history).
+        with(channel: '#random')
+    end
+
+    context 'when retrieving the channel history' do
+      it 'determines the top commenters in recent past' do
+        notifier = double(send_message: nil)
+        allow(Notifier).to receive(:new).and_return(notifier)
+        client = double(
+          channels_history: channel_history,
+          users_profile_get: user_data,
+        )
+        allow(Slack::Web::Client).to receive(:new).and_return(client)
+
+        StatsCalculator.new(channel: '#random').run
+
+        expect(notifier).to have_received(:send_message).
+          with(message: /Adarsh/)
+      end
+
+      it 'sends a nice message which ignores add messages and bots' do
+        notifier = double(send_message: nil)
+        allow(Notifier).to receive(:new).and_return(notifier)
+        client = double(
+          channels_history: channel_history,
+          users_profile_get: user_data,
+        )
+        allow(Slack::Web::Client).to receive(:new).and_return(client)
+
+        StatsCalculator.new(channel: '#random').run
+
+        expect(notifier).to have_received(:send_message).
+          with(message: "User 'Adarsh Pandit' is the top commentor with 2 messages")
+      end
+    end
+  end
+
+  def channel_history
+    JSON.parse(File.read('spec/helpers/fixtures/channel_history.json'))
+  end
+
+  def user_data
+    JSON.parse(File.read('spec/helpers/fixtures/user_data.json'))
+  end
+end

--- a/spec/support/capybara_webkit.rb
+++ b/spec/support/capybara_webkit.rb
@@ -1,5 +1,0 @@
-Capybara.javascript_driver = :webkit
-
-Capybara::Webkit.configure do |config|
-  config.block_unknown_urls
-end


### PR DESCRIPTION
Reason for Change
=================
* In order to let people know they are dominating a channel, we need to provide some data.

Changes
=======
* Add a JSON fixture file for returned channel history result. Spend too much time formatting it, because something is wrong with me.
* Write some tests but stub out the real network interactions. This is helpful because unstubbing them gives us live results in my test slack channel.
* Figure out who is blabbing the most and return that user's real name.

Minor
-----
* Add Rerun gem for workflow reasons (reruns specs after file changes)
* FactoryGirl is deprecated. Replace with FactoryBot.
* Clear the job queue before running tests
* Remove other references to Capybara Webkit since we are not using it
* Use Sidekiq as the activejob adapter
* Add the sidekiq testing library and use single quotes